### PR TITLE
Allow overriding output title by setting `page_title`

### DIFF
--- a/lib/middleman-title/helpers.rb
+++ b/lib/middleman-title/helpers.rb
@@ -3,6 +3,9 @@ module Middleman
     module Helpers
 
       def page_title
+        cur_page_title = current_page.data.page_title
+        return cur_page_title unless cur_page_title.nil?
+
         title = []
         title = add_page_name_to_title(title)
         title = add_website_name_to_title(title)

--- a/lib/middleman-title/helpers.rb
+++ b/lib/middleman-title/helpers.rb
@@ -3,8 +3,8 @@ module Middleman
     module Helpers
 
       def page_title
-        cur_page_title = current_page.data.page_title
-        return cur_page_title unless cur_page_title.nil?
+        current_page_title = current_page.data.page_title
+        return current_page_title unless current_page_title.nil?
 
         title = []
         title = add_page_name_to_title(title)

--- a/spec/extension_spec.rb
+++ b/spec/extension_spec.rb
@@ -12,6 +12,7 @@ describe Middleman::Title::Helpers do
       h.stub_chain(:current_page, :data, :title).and_return(nil)
       h.stub_chain(:current_page, :data, :title_site).and_return(nil)
       h.stub_chain(:current_page, :data, :title_reverse).and_return(nil)
+      h.stub_chain(:current_page, :data, :page_title).and_return(nil)
     end
 
     context 'website name is set' do
@@ -91,6 +92,14 @@ describe Middleman::Title::Helpers do
         end
       end
 
+    end
+
+    context 'page_title is set' do
+      before(:each) { h.stub_chain(:current_page, :data, :page_title).and_return('This takes precedence') }
+
+      it 'returns page_title specified for the current page' do
+        expect(h.page_title).to eq 'This takes precedence'
+      end
     end
 
   end


### PR DESCRIPTION
When setting `page_title: foobar` in the header of a page, `foobar` will always be returned by the `page_title` method.