### PR TITLE
Use CodeClimate binary to report code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,19 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=96d351848c244b986b3888fd13d12b6e916dcfbc83474c8a7a2c03d1c7827ecf
 language: ruby
 cache: bundler
-before_install:
-  - gem update bundler
 rvm:
+  - 2.4.0
   - 2.3.0
   - 2.2.0
   - 2.1.0
   - 2.0.0
-addons:
-  code_climate:
-    repo_token: 96d351848c244b986b3888fd13d12b6e916dcfbc83474c8a7a2c03d1c7827ecf
-after_success:
-  - bundle exec codeclimate-test-reporter
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+script:
+  - bundle exec rspec
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/middleman-title.gemspec
+++ b/middleman-title.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.3'
   spec.add_development_dependency 'rspec', '~> 2.14'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0.0'
 end


### PR DESCRIPTION
The Code Climate test reporter is now deprecated in favor of a binary. I
removed the reporter dependency, added simplecov as a dev dependency to
continue running locally, and updated the Travis config to run the
binary during CI.