### PR TITLE
GitHub Actions for CI (RSpec + CodeClimate Coverage)

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,32 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install Ruby (2.6)
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+
+    - name: Setup Code Climate test-reporter
+      run: |
+        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        chmod +x ./cc-test-reporter
+        ./cc-test-reporter before-build
+
+    - name: Build and test with RSpec
+      run: |
+        gem install bundler
+        bundle install --jobs 4 --retry 3
+        bundle exec rspec
+
+    - name: Publish code coverage
+      run: |
+        export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
+        ./cc-test-reporter after-build -r ${{secrets.CC_TEST_REPORTER_ID}}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Middleman Title
-[![Build Status](https://travis-ci.org/jcypret/middleman-title.svg?branch=master)](https://travis-ci.org/jcypret/middleman-title)
+![Build Status](https://github.com/jcypret/middleman-title/workflows/build/badge.svg?branch=master)
 [![Gem Version](https://badge.fury.io/rb/middleman-title.svg)](https://badge.fury.io/rb/middleman-title)
 [![Code Climate](https://codeclimate.com/github/jcypret/middleman-title/badges/gpa.svg)](https://codeclimate.com/github/jcypret/middleman-title)
 [![Test Coverage](https://codeclimate.com/github/jcypret/middleman-title/badges/coverage.svg)](https://codeclimate.com/github/jcypret/middleman-title/coverage)

--- a/middleman-title.gemspec
+++ b/middleman-title.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'middleman-core', '>= 4.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
-  spec.add_development_dependency 'rake', '~> 10.3'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 2.14'
   spec.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
Previously we were using Travis CI to run the specs and report back to GitHub, but now we'll be using the native CI build into GitHub called "Actions". This removes an extra dependency of this project. I also added in the code coverage reports for CodeClimate, updated the build badge in the README, and removed the explicit version on Bundler causing incompatibility with Bundler 2.x.